### PR TITLE
Fix auth parsing

### DIFF
--- a/umail.py
+++ b/umail.py
@@ -56,7 +56,7 @@ class SMTP:
         auths = None
         for feature in resp:
             if feature[:4].upper() == CMD_AUTH:
-                auths = feature[4:].upper().split()
+                auths = feature[4:].strip('=').upper().split()
         assert auths!=None, "no auth method"
 
         from ubinascii import b2a_base64 as b64


### PR DESCRIPTION
Thanks for the great lib, however I needed the following fix in order to authenticate:

Some mailservers (at least mine) return an AUTH line in the form
AUTH PLAIN LOGIN
AUTH=PLAIN LOGIN
the second line confusing the current AUTH parsing.
Fix by stripping away the equal sign.