### PR TITLE
Updated ussl module to use non-U naming scheme as a part of the new module naming scheme

### DIFF
--- a/umail.py
+++ b/umail.py
@@ -25,14 +25,14 @@ class SMTP:
         return int(code), resp
 
     def __init__(self, host, port, ssl=False, username=None, password=None):
-        import ussl
+        import ssl
         self.username = username
         addr = usocket.getaddrinfo(host, port)[0][-1]
         sock = usocket.socket(usocket.AF_INET, usocket.SOCK_STREAM)
         sock.settimeout(DEFAULT_TIMEOUT)
         sock.connect(addr)
         if ssl:
-            sock = ussl.wrap_socket(sock)
+            sock = ssl.wrap_socket(sock)
         code = int(sock.read(3))
         sock.readline()
         assert code==220, 'cant connect to server %d, %s' % (code, resp)
@@ -43,7 +43,7 @@ class SMTP:
         if not ssl and CMD_STARTTLS in resp:
             code, resp = self.cmd(CMD_STARTTLS)
             assert code==220, 'start tls failed %d, %s' % (code, resp)
-            self._sock = ussl.wrap_socket(sock)
+            self._sock = ssl.wrap_socket(sock)
 
         if username and password:
             self.login(username, password)

--- a/umail.py
+++ b/umail.py
@@ -1,7 +1,7 @@
 # uMail (MicroMail) for MicroPython
 # Copyright (c) 2018 Shawwwn <shawwwn1@gmail.com>
 # License: MIT
-import usocket
+import socket
 
 DEFAULT_TIMEOUT = 10 # sec
 LOCAL_DOMAIN = '127.0.0.1'
@@ -27,8 +27,8 @@ class SMTP:
     def __init__(self, host, port, ssl=False, username=None, password=None):
         import ssl
         self.username = username
-        addr = usocket.getaddrinfo(host, port)[0][-1]
-        sock = usocket.socket(usocket.AF_INET, usocket.SOCK_STREAM)
+        addr = socket.getaddrinfo(host, port)[0][-1]
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(DEFAULT_TIMEOUT)
         sock.connect(addr)
         if ssl:


### PR DESCRIPTION
I updated the library to import ssl instead of ussl because of the new package naming in Micropython.

See https://github.com/orgs/micropython/discussions/12602 for more information.